### PR TITLE
[Tecnical Support] SOS-2547 Removing user from group invite list doesn't work if filter doe...

### DIFF
--- a/portlets/so-portlet/docroot/invite_members/js/main.js
+++ b/portlets/so-portlet/docroot/invite_members/js/main.js
@@ -139,7 +139,10 @@ AUI.add(
 					var user = instance._findMembersList.one('[data-userId="' + userId + '"]');
 					var invitedUser = instance._invitedMembersList.one('[data-userId="' + userId + '"]');
 
-					user.removeClass('invited');
+					if (user) {
+						user.removeClass('invited');
+					}
+
 					invitedUser.remove();
 				},
 


### PR DESCRIPTION
...sn't match

Hi Istvan,

I'm sending a pull to you master branch without testing. I couldn't test it on master because the built portal bundle didn't work for me.

I could test my solution on 6.2.10-sp7 where main.js of invite_members portlet is the same as on master.

Thanks,
 Zsaga